### PR TITLE
Use NeosModLoader logging

### DIFF
--- a/NeosVideoPlayerFix/NeosVideoPlayerFix.csproj
+++ b/NeosVideoPlayerFix/NeosVideoPlayerFix.csproj
@@ -2,32 +2,37 @@
 
   <PropertyGroup>
     <TargetFramework>net4.7.2</TargetFramework>
+    <NeosPath>$(MSBuildThisFileDirectory)NeosVR</NeosPath>
+    <NeosPath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\NeosVR\')">C:\Program Files (x86)\Steam\steamapps\common\NeosVR\</NeosPath>
+    <NeosPath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/NeosVR/')">$(HOME)/.steam/steam/steamapps/common/NeosVR/</NeosPath>
+    <NeosPath Condition="Exists('/mnt/LocalDisk/SteamLibrary/steamapps/common/NeosVR/')">/mnt/LocalDisk/SteamLibrary/steamapps/common/NeosVR/</NeosPath>
   </PropertyGroup>
 
   <ItemGroup>
     <Reference Include="UnityNeos">
-      <HintPath>/mnt/LocalDisk/SteamLibrary/steamapps/common/NeosVR/Neos_Data/Managed/UnityNeos.dll</HintPath>
+      <HintPath>$(NeosPath)Neos_Data/Managed/UnityNeos.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>/mnt/LocalDisk/SteamLibrary/steamapps/common/NeosVR/Neos_Data/Managed/UnityEngine.dll</HintPath>
+      <HintPath>$(NeosPath)Neos_Data/Managed/UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="Assembly">
-      <HintPath>/mnt/LocalDisk/SteamLibrary/steamapps/common/NeosVR/Neos_Data/Managed/Assembly-CSharp.dll</HintPath>
+      <HintPath>$(NeosPath)Neos_Data/Managed/Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="NeosModLoader">
-      <HintPath>/mnt/LocalDisk/SteamLibrary/steamapps/common/NeosVR/NeosModLoader.dll</HintPath>
+      <HintPath>$(NeosPath)NeosModLoader.dll</HintPath>
+      <HintPath>$(NeosPath)Libraries/NeosModLoader.dll</HintPath>
     </Reference>
     <Reference Include="FrooxEngine">
-      <HintPath>/mnt/LocalDisk/SteamLibrary/steamapps/common/NeosVR/Neos_Data/Managed/FrooxEngine.dll</HintPath>
+      <HintPath>$(NeosPath)Neos_Data/Managed/FrooxEngine.dll</HintPath>
     </Reference>
     <Reference Include="BaseX">
-      <HintPath>/mnt/LocalDisk/SteamLibrary/steamapps/common/NeosVR/Neos_Data/Managed/BaseX.dll</HintPath>
+      <HintPath>$(NeosPath)Neos_Data/Managed/BaseX.dll</HintPath>
     </Reference>
     <Reference Include="NYoutubeDL">
-      <HintPath>/mnt/LocalDisk/SteamLibrary/steamapps/common/NeosVR/Neos_Data/Managed/NYoutubeDL.dll</HintPath>
+      <HintPath>$(NeosPath)Neos_Data/Managed/NYoutubeDL.dll</HintPath>
     </Reference>
     <Reference Include="HarmonyLib">
-      <HintPath>/mnt/LocalDisk/SteamLibrary/steamapps/common/NeosVR/0Harmony.dll</HintPath>
+      <HintPath>$(NeosPath)0Harmony.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/NeosVideoPlayerFix/NeosVideoPlayerFix.csproj
+++ b/NeosVideoPlayerFix/NeosVideoPlayerFix.csproj
@@ -25,9 +25,6 @@
     <Reference Include="FrooxEngine">
       <HintPath>$(NeosPath)Neos_Data/Managed/FrooxEngine.dll</HintPath>
     </Reference>
-    <Reference Include="BaseX">
-      <HintPath>$(NeosPath)Neos_Data/Managed/BaseX.dll</HintPath>
-    </Reference>
     <Reference Include="NYoutubeDL">
       <HintPath>$(NeosPath)Neos_Data/Managed/NYoutubeDL.dll</HintPath>
     </Reference>

--- a/NeosVideoPlayerFix/VideoPlayerFix.cs
+++ b/NeosVideoPlayerFix/VideoPlayerFix.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using HarmonyLib;
 using NeosModLoader;
 using FrooxEngine;
-using BaseX;
 using UnityNeos;
 using System.IO;
 using System.Linq;
@@ -31,7 +30,7 @@ namespace VideoPlayerFix
             if (nativePlayer != default)
             {
                 engines.Remove(nativePlayer);
-                UniLog.Log("Removed Unity Native from valid playback engines.");
+                Msg("Removed Unity Native from valid playback engines.");
             }
             harmony.PatchAll();
             
@@ -51,10 +50,10 @@ namespace VideoPlayerFix
                 var test = paths.FirstOrDefault(i => File.Exists($"{i}/{p}")) + $"/{p}";
                 if (test == $"/{p}") continue;
                 YoutubeDLPath = test;
-                UniLog.Log($"Patched NYoutubeDL with {p}: {test}");
+                Msg($"Patched NYoutubeDL with {p}: {test}");
                 return;
             }
-            UniLog.Log("Could not find a valid program to patch NYoutubeDL with");
+            Msg("Could not find a valid program to patch NYoutubeDL with");
         }
 
         [HarmonyPatch(typeof(UMPSettings))]
@@ -67,7 +66,7 @@ namespace VideoPlayerFix
                 //Fix video players by setting the library path properly
                 if (Engine.Current.Platform != Platform.Linux) return true;
                 __result = Path.Combine(Engine.Current.AppPath, "Neos_Data", "Plugins");
-                UniLog.Log("Patched library path: " + __result);
+                Msg("Patched library path: " + __result);
                 return false;
             }
         }
@@ -93,7 +92,7 @@ namespace VideoPlayerFix
                 //if mime is a specific value, it will use the force video player value, which can
                 //allow unity's player to run, which we don't want
                 mime = null;
-                UniLog.Log("Forced libVLC in a video player");
+                Msg("Forced libVLC in a video player");
             }
         }
         /*


### PR DESCRIPTION
NeosModLoader provides logging functionality which adds decorations to identify which mod is doing the logging, which is preferable over each mod doing their own logging shenanigans.

This PR would remove the use of Unilog in favor of it, and also make the build look for the references from standard paths as well so that more people can easily build it without needing to modify the .csproj file first.