### PR TITLE
Add nml_libs as HintPath

### DIFF
--- a/NeosVideoPlayerFix/NeosVideoPlayerFix.csproj
+++ b/NeosVideoPlayerFix/NeosVideoPlayerFix.csproj
@@ -30,6 +30,7 @@
     </Reference>
     <Reference Include="HarmonyLib">
       <HintPath>$(NeosPath)0Harmony.dll</HintPath>
+      <HintPath>$(NeosPath)nml_libs/0Harmony.dll</HintPath>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
This adds nml_libs as another hint path for HarmonyLib. As 0Harmony is generally installed in that folder, this makes for a more accessible building process.